### PR TITLE
Feat/dbg mapper support

### DIFF
--- a/bones/cmd/dbg.go
+++ b/bones/cmd/dbg.go
@@ -89,23 +89,8 @@ func startInteractiveDbg() {
 }
 
 func displayBreak(data dbg.BreakState) {
-	var startIdx int
-	var endIdx int
-
-	instIdx := data.Disass.IndexOf(data.Reg.PC)
-
-	if instIdx > 5 {
-		startIdx = instIdx - 5
-	}
-
-	if instIdx+5 < len(data.Disass.Code) {
-		endIdx = instIdx + 5
-	}
-
-	for i := startIdx; i <= endIdx; i++ {
-		inst := data.Disass.Code[i]
-
-		if i == instIdx {
+	for i, inst := range data.Code {
+		if i == data.PCIdx {
 			fmt.Printf("=> %04x: %s\n", inst.Addr, inst.Text)
 			continue
 		}

--- a/bones/cmd/dbg_commands.go
+++ b/bones/cmd/dbg_commands.go
@@ -46,13 +46,9 @@ func createCommands() map[string]*dbgCommand {
 					return false
 				}
 
-				ok := dw.Break(int(addr))
-				if !ok {
-					fmt.Printf("$%04x isn't a valid break address\n", addr)
-					return false
-				}
-
+				dw.Break(int(addr))
 				fmt.Printf("Breakpoint set at $%04x\n", addr)
+
 				return false
 			},
 

--- a/bones/cmd/disass.go
+++ b/bones/cmd/disass.go
@@ -33,7 +33,7 @@ var disassCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		d := disass.Disassemble(rom)
+		d := disass.DisassembleROM(rom)
 		for _, inst := range d.Code {
 			fmt.Printf("%04x: %s\n", inst.Addr, inst.Text)
 		}

--- a/cpu/worker.go
+++ b/cpu/worker.go
@@ -48,6 +48,8 @@ func NewWorker(rom *ines.ROM, disp ppu.Displayer, ctrl *controller.Controller) *
 }
 
 // Start starts running the NES.
+//
+// Start is blocking and should be run in a goroutine of it's own.
 func (w *Worker) Start() {
 	go w.handleNmi()
 

--- a/disass/disass.go
+++ b/disass/disass.go
@@ -51,9 +51,8 @@ func (d Disassembly) IndexOf(addr int) int {
 	return -1
 }
 
-// Disassemble is the main method of this package, taking the program and
-// returning the disassembled code.
-func Disassemble(rom *ines.ROM) Disassembly {
+// DisassembleROM takes a ROM and returnes it's disassembled code
+func DisassembleROM(rom *ines.ROM) Disassembly {
 	prgROM := rom.Mapper.GetPRGRom()
 
 	asm := genContiguousAsm(prgROM)


### PR DESCRIPTION
Implements and closes #25.

## Features
- `bones dbg` now correctly displays and disassembles the program when a mapper is used.